### PR TITLE
framesetter와 renderedAttributedText를 public으로 인터페이스 추가

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.h
+++ b/TTTAttributedLabel/TTTAttributedLabel.h
@@ -431,6 +431,16 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
  */
 - (TTTAttributedLabelLink *)linkAtPoint:(CGPoint)point;
 
+/// 현재 `CTFramesetter`를 리턴
+///
+/// 기존에는 `private`였던 메소드를  `public`으로 뚫어 사용한다.
+- (CTFramesetterRef)framesetter;
+
+/// 현재까지 설정된 속성을 기반으로 렌더링한 `NSAttributedString`을 리턴
+///
+/// 기존에는 `private`였던 메소드를  `public`으로 뚫어 사용한다.
+- (NSAttributedString *)renderedAttributedText;
+
 @end
 
 /**


### PR DESCRIPTION
## 이슈
- 웍스 앱 프로젝트의 `WOLabel`을 swift 전환하던 중에 private 요소를 쓰고 있는 것을 발견
- swift 단에서는 현재 사용할 수 있는 방법이 없어 public하게 전환 필요

## 수정 사항
- public하게 전환하기 위해 헤더파일에 관련 메소드 추가

## 참고 사항
- 바로 `master-works` 상대로 PR을 올릴까 하다가 `develop`으로 올렸습니다. 문제가 있다면 말씀주세요!
- git flow
  - `master-works`(`master` base)
  - `develop`(`master-works` base)